### PR TITLE
Implement pretty-printing of several constructs

### DIFF
--- a/psc-format/Binder.hs
+++ b/psc-format/Binder.hs
@@ -4,11 +4,12 @@ import Prelude
 import Text.PrettyPrint.ANSI.Leijen
 import Language.PureScript.AST.Binders
 import Data.List (intersperse)
+import Literals
 import Names
 
 instance Pretty Binder where
     pretty NullBinder = text "_"
-    pretty (LiteralBinder literalBinder) = text "LiteralBinder"
+    pretty (LiteralBinder literalBinder) = pretty literalBinder
     pretty (VarBinder ident) = pretty ident
     pretty (ConstructorBinder constructorName binders) = pretty constructorName <> bs
         where

--- a/psc-format/Binder.hs
+++ b/psc-format/Binder.hs
@@ -19,7 +19,7 @@ instance Pretty Binder where
     pretty (OpBinder valueOpName) = text "OpBinder"
     pretty (BinaryNoParensBinder binder1 binder2 binder3) = text "BinaryNoParensBinder"
     pretty (ParensInBinder binder) = parens . pretty $ binder
-    pretty (NamedBinder ident binder) = text "NamedBinder"
+    pretty (NamedBinder ident binder) = pretty ident <> text "@" <> pretty binder
     pretty (PositionedBinder _ comments binder) = pretty binder
     pretty (TypedBinder typ binder) = text "TypedBinder"
 

--- a/psc-format/Comments.hs
+++ b/psc-format/Comments.hs
@@ -8,6 +8,6 @@ import Language.PureScript.Comments
 
 instance Pretty Comment where
     pretty (LineComment s) = text "--" <> pretty s
-    pretty (BlockComment s) = text "--" <> pretty s
+    pretty (BlockComment s) = text "{-" <> pretty s <> text "-}"
 
     prettyList = vcat . fmap pretty

--- a/psc-format/Declarations.hs
+++ b/psc-format/Declarations.hs
@@ -79,7 +79,12 @@ instance Pretty Declaration where
     pretty (ExternDeclaration tdent typ) = text "ExternDeclaration"
     pretty (ExternDataDeclaration properName kin) = text "ExternDataDeclaration"
     pretty (FixityDeclaration fixity) = text "FixityDeclaration"
-    pretty (ImportDeclaration moduleName importDeclarationType qualifiedModuleName) = text "import" <+> pretty moduleName <> pretty importDeclarationType <> pretty qualifiedModuleName
+    pretty (ImportDeclaration moduleName importDeclarationType qualifiedModuleName) =
+        text "import" <+> pretty moduleName <> importBody
+        where
+            importBody = case qualifiedModuleName of
+                Nothing -> pretty importDeclarationType
+                Just qualifiedModuleName' -> pretty importDeclarationType <+> text "as" <+> pretty qualifiedModuleName'
     pretty (TypeClassDeclaration properName a constraints declarations) = text "TypeClassDeclarationsss"
     pretty (TypeInstanceDeclaration ident constraints qualified types typeInstanceBody)
         = text "instance" <+> pretty ident <+> text "::" <+> pretty qualified <+> printTypeConstructors types <+> text "where"

--- a/psc-format/Declarations.hs
+++ b/psc-format/Declarations.hs
@@ -76,7 +76,8 @@ instance Pretty Declaration where
         in
             pretty ident <> bs <+> text "=" <$> PP.indent indentationLevel e
     pretty (BindingGroupDeclaration is) = text "BindingGroupDeclaration"
-    pretty (ExternDeclaration tdent typ) = text "ExternDeclaration"
+    pretty (ExternDeclaration tdent typ) =
+      text "foreign" <+> text "import" <+> pretty tdent <+> text "::" <+> pretty typ
     pretty (ExternDataDeclaration properName kin) = text "ExternDataDeclaration"
     pretty (FixityDeclaration fixity) = text "FixityDeclaration"
     pretty (ImportDeclaration moduleName importDeclarationType qualifiedModuleName) =

--- a/psc-format/Declarations.hs
+++ b/psc-format/Declarations.hs
@@ -118,7 +118,7 @@ instance Pretty Expr where
     pretty (TypeClassDictionaryAccessor qualified ident) = text "TypeClassDictionaryAccessor"
     pretty (SuperClassDictionary qualified types) = text "SuperClassDictionary"
     pretty AnonymousArgument = text "_"
-    pretty (Hole hole) = text hole
+    pretty (Hole hole) = text "?" <> text hole
     pretty (PositionedValue sourceSpan comments expr) = pretty expr
 
 instance Pretty ImportDeclarationType where

--- a/psc-format/Literals.hs
+++ b/psc-format/Literals.hs
@@ -1,12 +1,14 @@
 module Literals where
 
-import Prelude ((++), ($), fmap)
+import Prelude (Either(Left, Right), (++), ($), fmap)
 import Text.PrettyPrint.ANSI.Leijen
 import Language.PureScript.AST.Literals (Literal (..))
 import Pretty
 
 instance Pretty a => Pretty (Literal a) where
-    pretty (NumericLiteral id) = text "integer or double"
+    pretty (NumericLiteral integerOrDouble) = case integerOrDouble of
+      Left integer -> pretty integer
+      Right number -> pretty number
     pretty (StringLiteral s) = text ("\"" ++ s ++ "\"")
     pretty (CharLiteral c) = text ['\'', c, '\'']
     pretty (BooleanLiteral b) = text $ if b then "true" else "false"


### PR DESCRIPTION
Implements pretty-printing of the following:
- Qualified imports
- Literal binders
- Named binders
- Block comments
- Numeric literals
- Foreign function declarations
- Typed holes
